### PR TITLE
Remove chevron arrow from service cards without content

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -784,7 +784,6 @@ export default function Index() {
                     >
                       <service.icon className="h-5 w-5 sm:h-6 sm:w-6 text-white" />
                     </div>
-                    <ChevronRight className="h-4 w-4 sm:h-5 sm:w-5 text-muted-foreground group-hover:text-primary group-hover:translate-x-1 transition-all duration-300" />
                   </div>
                   <CardTitle className="text-lg sm:text-xl font-bold group-hover:text-primary transition-colors duration-300">
                     {service.title}


### PR DESCRIPTION
## Purpose
Remove unnecessary chevron arrows from service cards that don't contain any content inside them, as requested by the user to clean up the UI.

## Code changes
- Removed the `ChevronRight` component from service card items in `client/pages/Index.tsx`
- Eliminated the arrow icon with hover animations and transitions that was previously displayed on each service cardTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b77c975942a74625adb8502ac720d627/swoosh-nest)

👀 [Preview Link](https://b77c975942a74625adb8502ac720d627-swoosh-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b77c975942a74625adb8502ac720d627</projectId>-->
<!--<branchName>swoosh-nest</branchName>-->