### PR TITLE
Refactor: Update internal link paths for consistency

### DIFF
--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -28,7 +28,7 @@ export function Footer() {
             <ul className="space-y-2 text-white/80">
               <li>
                 <Link
-                  to="/services/soc2-readiness"
+                  to="/soc2-readiness"
                   className="hover:text-accent transition-colors"
                 >
                   SOC 2 Readiness
@@ -36,7 +36,7 @@ export function Footer() {
               </li>
               <li>
                 <Link
-                  to="/services/penetration-testing"
+                  to="/penetration-testing"
                   className="hover:text-accent transition-colors"
                 >
                   Penetration Testing
@@ -44,7 +44,7 @@ export function Footer() {
               </li>
               <li>
                 <Link
-                  to="/services/cloud-security"
+                  to="/cloud-security"
                   className="hover:text-accent transition-colors"
                 >
                   Cloud Security
@@ -52,7 +52,7 @@ export function Footer() {
               </li>
               <li>
                 <Link
-                  to="/services/compliance-audit-readiness"
+                  to="/compliance-audit-readiness"
                   className="hover:text-accent transition-colors"
                 >
                   Audit Readiness

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -41,37 +41,37 @@ export function Navigation() {
               <div className="absolute top-full left-0 mt-2 w-64 bg-white rounded-lg shadow-xl border opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
                 <div className="py-2">
                   <Link
-                    to="/services/compliance-audit-readiness"
+                    to="/compliance-audit-readiness"
                     className="block px-4 py-2 text-sm text-red-600 hover:text-green-600 hover:bg-accent/10 transition-colors font-semibold"
                   >
                     Compliance and Audit Readiness
                   </Link>
                   <Link
-                    to="/services/penetration-testing"
+                    to="/penetration-testing"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     Penetration Testing
                   </Link>
                   <Link
-                    to="/services/it-support"
+                    to="/it-support"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     IT Support
                   </Link>
                   <Link
-                    to="/services/soc-support"
+                    to="/soc-support"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     SOC Support
                   </Link>
                   <Link
-                    to="/services/security-training"
+                    to="/security-training"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     Security Training
                   </Link>
                   <Link
-                    to="/services/risk-management"
+                    to="/risk-management"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     Risk Management
@@ -270,42 +270,42 @@ export function Navigation() {
                   <div className="px-4 pb-3 bg-gray-50">
                     <div className="flex flex-col space-y-1">
                       <Link
-                        to="/services/compliance-audit-readiness"
+                        to="/compliance-audit-readiness"
                         className="block px-3 py-2 text-sm text-red-600 hover:text-green-600 hover:bg-white rounded transition-colors font-semibold"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         Compliance and Audit Readiness
                       </Link>
                       <Link
-                        to="/services/penetration-testing"
+                        to="/penetration-testing"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         Penetration Testing
                       </Link>
                       <Link
-                        to="/services/it-support"
+                        to="/it-support"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         IT Support
                       </Link>
                       <Link
-                        to="/services/soc-support"
+                        to="/soc-support"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         SOC Support
                       </Link>
                       <Link
-                        to="/services/security-training"
+                        to="/security-training"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         Security Training
                       </Link>
                       <Link
-                        to="/services/risk-management"
+                        to="/risk-management"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -179,19 +179,19 @@ export function Navigation() {
               <div className="absolute top-full left-0 mt-2 w-48 bg-white rounded-lg shadow-xl border opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
                 <div className="py-2">
                   <Link
-                    to="/about/company"
+                    to="/company"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     Our Company
                   </Link>
                   <Link
-                    to="/about/careers"
+                    to="/careers"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     Careers
                   </Link>
                   <Link
-                    to="/about/team"
+                    to="/team"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     Team
@@ -457,21 +457,21 @@ export function Navigation() {
                   <div className="px-4 pb-3 bg-gray-50">
                     <div className="flex flex-col space-y-1">
                       <Link
-                        to="/about/company"
+                        to="/company"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         Our Company
                       </Link>
                       <Link
-                        to="/about/careers"
+                        to="/careers"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         Careers
                       </Link>
                       <Link
-                        to="/about/team"
+                        to="/team"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -89,19 +89,19 @@ export function Navigation() {
               <div className="absolute top-full left-0 mt-2 w-48 bg-white rounded-lg shadow-xl border opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
                 <div className="py-2">
                   <Link
-                    to="/resources/blogs"
+                    to="/blogs"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     Blogs
                   </Link>
                   <Link
-                    to="/resources/approach"
+                    to="/approach"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     Approach
                   </Link>
                   <Link
-                    to="/resources/phishing"
+                    to="/phishing"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     Phishing Test
@@ -418,14 +418,14 @@ export function Navigation() {
                   <div className="px-4 pb-3 bg-gray-50">
                     <div className="flex flex-col space-y-1">
                       <Link
-                        to="/resources/blogs"
+                        to="/blogs"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         Blogs
                       </Link>
                       <Link
-                        to="/resources/approach"
+                        to="/approach"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -119,49 +119,49 @@ export function Navigation() {
               <div className="absolute top-full left-0 mt-2 w-48 bg-white rounded-lg shadow-xl border opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
                 <div className="py-2">
                   <Link
-                    to="/frameworks/soc2"
+                    to="/soc2"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     SOC 2
                   </Link>
                   <Link
-                    to="/frameworks/iso27001"
+                    to="/iso27001"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     ISO 27001
                   </Link>
                   <Link
-                    to="/frameworks/hitrust"
+                    to="/hitrust"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     HITRUST
                   </Link>
                   <Link
-                    to="/frameworks/hipaa"
+                    to="/hipaa"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     HIPAA
                   </Link>
                   <Link
-                    to="/frameworks/pci-dss"
+                    to="/pci-dss"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     PCI-DSS
                   </Link>
                   <Link
-                    to="/frameworks/nist"
+                    to="/nist"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     NIST
                   </Link>
                   <Link
-                    to="/frameworks/gdpr"
+                    to="/gdpr"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     GDPR
                   </Link>
                   <Link
-                    to="/frameworks/cmmc"
+                    to="/cmmc"
                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-accent/10 hover:text-accent transition-colors"
                   >
                     CMMC
@@ -337,56 +337,56 @@ export function Navigation() {
                   <div className="px-4 pb-3 bg-gray-50">
                     <div className="flex flex-col space-y-1">
                       <Link
-                        to="/frameworks/soc2"
+                        to="/soc2"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         SOC 2
                       </Link>
                       <Link
-                        to="/frameworks/iso27001"
+                        to="/iso27001"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         ISO 27001
                       </Link>
                       <Link
-                        to="/frameworks/hitrust"
+                        to="/hitrust"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         HITRUST
                       </Link>
                       <Link
-                        to="/frameworks/hipaa"
+                        to="/hipaa"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         HIPAA
                       </Link>
                       <Link
-                        to="/frameworks/pci-dss"
+                        to="/pci-dss"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         PCI-DSS
                       </Link>
                       <Link
-                        to="/frameworks/nist"
+                        to="/nist"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         NIST
                       </Link>
                       <Link
-                        to="/frameworks/gdpr"
+                        to="/gdpr"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >
                         GDPR
                       </Link>
                       <Link
-                        to="/frameworks/cmmc"
+                        to="/cmmc"
                         className="block px-3 py-2 text-sm text-gray-700 hover:text-accent hover:bg-white rounded transition-colors"
                         onClick={() => setIsMenuOpen(false)}
                       >

--- a/client/main.tsx
+++ b/client/main.tsx
@@ -189,6 +189,8 @@ const App = () => (
             <Route path="/blogs" element={<Blogs />} />
             <Route path="/approach" element={<Approach />} />
             <Route path="/phishing" element={<PhishingTest />} />
+            <Route path="/approach" element={<Approach />} />
+            <Route path="/phishing" element={<PhishingTest />} />
 
             {/* About Routes */}
             <Route path="/about/company" element={<Company />} />
@@ -260,6 +262,23 @@ const App = () => (
               path="/resources/blog/safeguarding-data-sharing-tech-companies"
               element={<SafeguardingDataSharingTechCompanies />}
             />
+            {/* Top-level Blog Post Routes (duplicates for new paths) */}
+            <Route path="/blog/iso-27001-certification-guide" element={<Iso27001Guide />} />
+            <Route path="/blog/why-soc2-matters-small-companies" element={<Soc2SmallCompanies />} />
+            <Route path="/blog/meet-team-jayush-chawla" element={<MeetTeamJayush />} />
+            <Route path="/blog/meet-team-rojin-rezaei" element={<MeetTeamRojin />} />
+            <Route path="/blog/internal-vs-external-penetration-testing" element={<PentestingComparison />} />
+            <Route path="/blog/prepare-compliance-audit-best-practices" element={<PrepareComplianceAudit />} />
+            <Route path="/blog/what-is-vciso-role-cybersecurity" element={<WhatIsVciso />} />
+            <Route path="/blog/managed-security-compliance-services" element={<ManagedSecurityCompliance />} />
+            <Route path="/blog/ai-ethics-healthcare-innovation" element={<AiEthicsHealthcare />} />
+            <Route path="/blog/patient-confidentiality-ai-healthcare" element={<PatientConfidentialityAi />} />
+            <Route path="/blog/human-side-ai-patient-safety" element={<HumanSideAiPatientSafety />} />
+            <Route path="/blog/soc2-vs-iso27001-comparison" element={<Soc2VsIso27001 />} />
+            <Route path="/blog/transparency-accuracy-ai-healthcare" element={<TransparencyAccuracyAiHealthcare />} />
+            <Route path="/blog/cybersecurity-roundup-startups-may" element={<CybersecurityRoundupStartupsMay />} />
+            <Route path="/blog/security-compliance-health-companies" element={<SecurityComplianceHealthCompanies />} />
+            <Route path="/blog/safeguarding-data-sharing-tech-companies" element={<SafeguardingDataSharingTechCompanies />} />
             {/* Top-level Blog Post Routes (duplicates for new paths) */}
             <Route path="/blog/iso-27001-certification-guide" element={<Iso27001Guide />} />
             <Route path="/blog/why-soc2-matters-small-companies" element={<Soc2SmallCompanies />} />

--- a/client/main.tsx
+++ b/client/main.tsx
@@ -181,6 +181,15 @@ const App = () => (
             <Route path="/frameworks/nist" element={<Nist />} />
             <Route path="/frameworks/gdpr" element={<Gdpr />} />
             <Route path="/frameworks/cmmc" element={<Cmmc />} />
+            {/* Top-level Framework Routes (duplicates for new paths) */}
+            <Route path="/soc2" element={<Soc2Framework />} />
+            <Route path="/iso27001" element={<Iso27001 />} />
+            <Route path="/hipaa" element={<Hipaa />} />
+            <Route path="/hitrust" element={<Hitrust />} />
+            <Route path="/pci-dss" element={<PciDss />} />
+            <Route path="/nist" element={<Nist />} />
+            <Route path="/gdpr" element={<Gdpr />} />
+            <Route path="/cmmc" element={<Cmmc />} />
 
             {/* Resource Routes */}
             <Route path="/resources/blogs" element={<Blogs />} />

--- a/client/main.tsx
+++ b/client/main.tsx
@@ -205,6 +205,10 @@ const App = () => (
             <Route path="/about/company" element={<Company />} />
             <Route path="/about/careers" element={<Careers />} />
             <Route path="/about/team" element={<Team />} />
+            {/* Top-level About Routes (duplicates for new paths) */}
+            <Route path="/company" element={<Company />} />
+            <Route path="/careers" element={<Careers />} />
+            <Route path="/team" element={<Team />} />
 
             {/* Blog Post Routes */}
             <Route

--- a/client/main.tsx
+++ b/client/main.tsx
@@ -186,6 +186,9 @@ const App = () => (
             <Route path="/resources/blogs" element={<Blogs />} />
             <Route path="/resources/approach" element={<Approach />} />
             <Route path="/resources/phishing" element={<PhishingTest />} />
+            <Route path="/blogs" element={<Blogs />} />
+            <Route path="/approach" element={<Approach />} />
+            <Route path="/phishing" element={<PhishingTest />} />
 
             {/* About Routes */}
             <Route path="/about/company" element={<Company />} />
@@ -257,6 +260,23 @@ const App = () => (
               path="/resources/blog/safeguarding-data-sharing-tech-companies"
               element={<SafeguardingDataSharingTechCompanies />}
             />
+            {/* Top-level Blog Post Routes (duplicates for new paths) */}
+            <Route path="/blog/iso-27001-certification-guide" element={<Iso27001Guide />} />
+            <Route path="/blog/why-soc2-matters-small-companies" element={<Soc2SmallCompanies />} />
+            <Route path="/blog/meet-team-jayush-chawla" element={<MeetTeamJayush />} />
+            <Route path="/blog/meet-team-rojin-rezaei" element={<MeetTeamRojin />} />
+            <Route path="/blog/internal-vs-external-penetration-testing" element={<PentestingComparison />} />
+            <Route path="/blog/prepare-compliance-audit-best-practices" element={<PrepareComplianceAudit />} />
+            <Route path="/blog/what-is-vciso-role-cybersecurity" element={<WhatIsVciso />} />
+            <Route path="/blog/managed-security-compliance-services" element={<ManagedSecurityCompliance />} />
+            <Route path="/blog/ai-ethics-healthcare-innovation" element={<AiEthicsHealthcare />} />
+            <Route path="/blog/patient-confidentiality-ai-healthcare" element={<PatientConfidentialityAi />} />
+            <Route path="/blog/human-side-ai-patient-safety" element={<HumanSideAiPatientSafety />} />
+            <Route path="/blog/soc2-vs-iso27001-comparison" element={<Soc2VsIso27001 />} />
+            <Route path="/blog/transparency-accuracy-ai-healthcare" element={<TransparencyAccuracyAiHealthcare />} />
+            <Route path="/blog/cybersecurity-roundup-startups-may" element={<CybersecurityRoundupStartupsMay />} />
+            <Route path="/blog/security-compliance-health-companies" element={<SecurityComplianceHealthCompanies />} />
+            <Route path="/blog/safeguarding-data-sharing-tech-companies" element={<SafeguardingDataSharingTechCompanies />} />
             <Route path="/about" element={<About />} />
 
             <Route path="/testimonials" element={<Testimonials />} />

--- a/client/main.tsx
+++ b/client/main.tsx
@@ -162,14 +162,14 @@ const App = () => (
               element={<RiskManagement />}
             />
 
-{/* <Route path="/compliance-audit-readiness" element={<ComplianceAuditReadiness />} />
+<Route path="/compliance-audit-readiness" element={<ComplianceAuditReadiness />} />
 <Route path="/penetration-testing" element={<PenetrationTesting />} />
 <Route path="/it-support" element={<ItSupport />} />
 <Route path="/soc-support" element={<SocSupport />} />
 <Route path="/soc2-readiness" element={<Soc2Readiness />} />
 <Route path="/cloud-security" element={<CloudSecurity />} />
 <Route path="/security-training" element={<SecurityTraining />} />
-<Route path="/risk-management" element={<RiskManagement />} /> */}
+<Route path="/risk-management" element={<RiskManagement />} />
 
 
             {/* Framework Routes */}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -722,7 +722,7 @@ export default function Index() {
                   "Audit Preparation",
                 ],
                 color: "from-blue-500 to-cyan-500",
-                href: "/services/soc2-readiness",
+                href: "/soc2-readiness",
               },
               {
                 icon: Search,
@@ -735,7 +735,7 @@ export default function Index() {
                   "Social Engineering",
                 ],
                 color: "from-red-500 to-pink-500",
-                href: "/services/penetration-testing",
+                href: "/penetration-testing",
               },
               {
                 icon: Lock,
@@ -744,7 +744,7 @@ export default function Index() {
                   "Secure your cloud infrastructure with best practices and continuous monitoring.",
                 features: ["AWS Security", "Azure Security", "GCP Security"],
                 color: "from-green-500 to-emerald-500",
-                href: "/services/cloud-security",
+                href: "/cloud-security",
               },
               {
                 icon: FileCheck,
@@ -753,7 +753,7 @@ export default function Index() {
                   "Comprehensive audits for HIPAA, ISO 27001, and other regulatory frameworks.",
                 features: ["HIPAA Compliance", "ISO 27001", "GDPR Compliance"],
                 color: "from-purple-500 to-violet-500",
-                href: "/services/compliance-audit-readiness",
+                href: "/compliance-audit-readiness",
               },
               {
                 icon: Users,
@@ -766,7 +766,7 @@ export default function Index() {
                   "Incident Response",
                 ],
                 color: "from-orange-500 to-amber-500",
-                href: "/services/security-training",
+                href: "/security-training",
               },
               {
                 icon: CheckCircle,
@@ -779,7 +779,7 @@ export default function Index() {
                   "Control Testing",
                 ],
                 color: "from-teal-500 to-cyan-500",
-                href: "/services/risk-management",
+                href: "/risk-management",
               },
             ].map((service, index) => (
               <Link to={service.href ?? "/services"} key={index} className="block h-full no-underline" title={`Learn more about ${service.title}`}>

--- a/client/pages/Services.tsx
+++ b/client/pages/Services.tsx
@@ -77,7 +77,7 @@ export default function Services() {
                     className="border-accent text-accent hover:bg-accent hover:text-white"
                     asChild
                   >
-                    <Link to="/services/soc2-readiness">
+                    <Link to="/soc2-readiness">
                       Get Started <ChevronRight className="ml-1 h-4 w-4" />
                     </Link>
                   </Button>
@@ -118,7 +118,7 @@ export default function Services() {
                     className="border-accent text-accent hover:bg-accent hover:text-white"
                     asChild
                   >
-                    <Link to="/services/penetration-testing">
+                    <Link to="/penetration-testing">
                       Get Started <ChevronRight className="ml-1 h-4 w-4" />
                     </Link>
                   </Button>
@@ -159,7 +159,7 @@ export default function Services() {
                     className="border-accent text-accent hover:bg-accent hover:text-white"
                     asChild
                   >
-                    <Link to="/services/cloud-security">
+                    <Link to="/cloud-security">
                       Get Started <ChevronRight className="ml-1 h-4 w-4" />
                     </Link>
                   </Button>

--- a/client/pages/about/Team.tsx
+++ b/client/pages/about/Team.tsx
@@ -361,7 +361,7 @@ export default function Team() {
             className="bg-gradient-to-r from-accent to-orange-600 hover:from-accent/80 hover:to-orange-500 text-white transform hover:scale-105 transition-all duration-300"
             asChild
           >
-            <Link to="/about/careers">
+            <Link to="/careers">
               View Open Positions
               <ChevronRight className="ml-2 h-5 w-5" />
             </Link>

--- a/client/pages/frameworks/Hipaa.tsx
+++ b/client/pages/frameworks/Hipaa.tsx
@@ -605,7 +605,7 @@ export default function Hipaa() {
               className="bg-gradient-to-r from-green-600 to-teal-700 hover:from-green-500 hover:to-teal-600 transform hover:scale-105 transition-all duration-300"
               asChild
             >
-              <Link to="/services/compliance-audit-readiness">
+              <Link to="/compliance-audit-readiness">
                 Start HIPAA Assessment
                 <ChevronRight className="ml-2 h-5 w-5" />
               </Link>

--- a/client/pages/frameworks/Hitrust.tsx
+++ b/client/pages/frameworks/Hitrust.tsx
@@ -611,7 +611,7 @@ export default function Hitrust() {
               className="bg-gradient-to-r from-red-600 to-pink-700 hover:from-red-500 hover:to-pink-600 transform hover:scale-105 transition-all duration-300"
               asChild
             >
-              <Link to="/services/compliance-audit-readiness">
+              <Link to="/compliance-audit-readiness">
                 Start HITRUST Assessment
                 <ChevronRight className="ml-2 h-5 w-5" />
               </Link>

--- a/client/pages/frameworks/Iso27001.tsx
+++ b/client/pages/frameworks/Iso27001.tsx
@@ -680,7 +680,7 @@ export default function Iso27001() {
               className="bg-gradient-to-r from-blue-600 to-purple-700 hover:from-blue-500 hover:to-purple-600 transform hover:scale-105 transition-all duration-300"
               asChild
             >
-              <Link to="/services/compliance-audit-readiness">
+              <Link to="/compliance-audit-readiness">
                 Start Implementation
                 <ChevronRight className="ml-2 h-5 w-5" />
               </Link>

--- a/client/pages/frameworks/Soc2.tsx
+++ b/client/pages/frameworks/Soc2.tsx
@@ -414,7 +414,7 @@ export default function Soc2() {
               className="bg-gradient-to-r from-accent to-orange-600 hover:from-accent/90 hover:to-orange-600/90 transform hover:scale-105 transition-all duration-300"
               asChild
             >
-              <Link to="/services/soc2-readiness">
+              <Link to="/soc2-readiness">
                 Start SOC 2 Readiness
                 <ChevronRight className="ml-2 h-5 w-5" />
               </Link>

--- a/client/pages/resources/Blogs.tsx
+++ b/client/pages/resources/Blogs.tsx
@@ -205,7 +205,7 @@ export default function Blogs() {
             </h2>
           </div>
 
-          <Link to="/resources/blog/iso-27001-certification-guide">
+          <Link to="/blog/iso-27001-certification-guide">
             <Card className="hover:shadow-2xl transition-all duration-500 border-0 shadow-xl overflow-hidden group">
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-0">
                 <div className="bg-gradient-to-br from-blue-600 to-indigo-700 p-8 lg:p-12 text-white">
@@ -865,7 +865,7 @@ export default function Blogs() {
               .map((article, index) => (
                 <Link
                   key={index}
-                  to={`/resources/blog/${article.id}`}
+                  to={`/blog/${article.id}`}
                   data-article-title={article.title}
                   data-article-category={article.category}
                   data-article-excerpt={article.excerpt}

--- a/client/pages/resources/blog/20YearsCybersecurityJourney.tsx
+++ b/client/pages/resources/blog/20YearsCybersecurityJourney.tsx
@@ -33,7 +33,7 @@ export default function TwentyYearsCybersecurityJourney() {
       {/* Hero Section */}
       <section className="pt-24 pb-16 bg-gradient-to-br from-gray-900 via-slate-800 to-blue-900 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link to="/resources/blogs">
+          <Link to="/blogs">
             <Button
               variant="ghost"
               className="text-white hover:text-blue-300 mb-8 group"
@@ -385,7 +385,7 @@ export default function TwentyYearsCybersecurityJourney() {
                           <li>• Zero Trust Architecture adoption</li>
                           <li>• SASE and cloud security</li>
                           <li>• Extended detection and response</li>
-                          <li>• Identity-centric security</li>
+                          <li>�� Identity-centric security</li>
                         </ul>
                       </div>
                     </div>

--- a/client/pages/resources/blog/AiEthicsHealthcare.tsx
+++ b/client/pages/resources/blog/AiEthicsHealthcare.tsx
@@ -31,7 +31,7 @@ export default function AiEthicsHealthcare() {
       {/* Hero Section */}
       <section className="pt-24 pb-16 bg-gradient-to-br from-teal-900 via-teal-800 to-cyan-900 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link to="/resources/blogs">
+          <Link to="/blogs">
             <Button
               variant="ghost"
               className="text-white hover:text-teal-300 mb-8 group"

--- a/client/pages/resources/blog/CybersecurityRoundupStartupsMay.tsx
+++ b/client/pages/resources/blog/CybersecurityRoundupStartupsMay.tsx
@@ -36,7 +36,7 @@ export default function CybersecurityRoundupStartupsMay() {
       {/* Hero Section */}
       <section className="pt-24 pb-16 bg-gradient-to-br from-orange-900 via-red-800 to-pink-900 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link to="/resources/blogs">
+          <Link to="/blogs">
             <Button
               variant="ghost"
               className="text-white hover:text-orange-300 mb-8 group"

--- a/client/pages/resources/blog/HumanSideAiPatientSafety.tsx
+++ b/client/pages/resources/blog/HumanSideAiPatientSafety.tsx
@@ -30,7 +30,7 @@ export default function HumanSideAiPatientSafety() {
       {/* Hero Section */}
       <section className="pt-24 pb-16 bg-gradient-to-br from-blue-900 via-indigo-800 to-purple-900 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link to="/resources/blogs">
+          <Link to="/blogs">
             <Button
               variant="ghost"
               className="text-white hover:text-blue-300 mb-8 group"

--- a/client/pages/resources/blog/Iso27001Guide.tsx
+++ b/client/pages/resources/blog/Iso27001Guide.tsx
@@ -413,7 +413,7 @@ export default function Iso27001Guide() {
                     </Link>
                   </Button>
                   <Button variant="outline" asChild>
-                    <Link to="/frameworks/iso27001">
+                    <Link to="/iso27001">
                       Get ISO 27001 Certified
                     </Link>
                   </Button>

--- a/client/pages/resources/blog/Iso27001Guide.tsx
+++ b/client/pages/resources/blog/Iso27001Guide.tsx
@@ -32,7 +32,7 @@ export default function Iso27001Guide() {
 
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
           <Link
-            to="/resources/blogs"
+            to="/blogs"
             className="inline-flex items-center text-blue-200 hover:text-white transition-colors mb-8 group"
           >
             <ArrowLeft className="h-4 w-4 mr-2 group-hover:-translate-x-1 transition-transform" />
@@ -436,21 +436,21 @@ export default function Iso27001Guide() {
                 title: "Why SOC 2 Matters—Even If You're Not a Big Company?",
                 excerpt:
                   "Discover why SOC 2 compliance is crucial for companies of all sizes",
-                link: "/resources/blog/why-soc2-matters-small-companies",
+                link: "/blog/why-soc2-matters-small-companies",
                 category: "Compliance",
               },
               {
                 title: "How to Prepare for a Compliance Audit",
                 excerpt:
                   "Essential strategies for successful compliance audits",
-                link: "/resources/blog/prepare-compliance-audit-best-practices",
+                link: "/blog/prepare-compliance-audit-best-practices",
                 category: "Audit Readiness",
               },
               {
                 title: "What is a vCISO?",
                 excerpt:
                   "Understanding the role of virtual Chief Information Security Officers",
-                link: "/resources/blog/what-is-vciso-role-cybersecurity",
+                link: "/blog/what-is-vciso-role-cybersecurity",
                 category: "Leadership",
               },
             ].map((article, index) => (

--- a/client/pages/resources/blog/ManagedSecurityCompliance.tsx
+++ b/client/pages/resources/blog/ManagedSecurityCompliance.tsx
@@ -32,7 +32,7 @@ export default function ManagedSecurityCompliance() {
       {/* Hero Section */}
       <section className="pt-24 pb-16 bg-gradient-to-br from-slate-900 via-slate-800 to-gray-900 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link to="/resources/blogs">
+          <Link to="/blogs">
             <Button
               variant="ghost"
               className="text-white hover:text-blue-300 mb-8 group"

--- a/client/pages/resources/blog/MeetTeamJayush.tsx
+++ b/client/pages/resources/blog/MeetTeamJayush.tsx
@@ -35,7 +35,7 @@ export default function MeetTeamJayush() {
 
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
           <Link
-            to="/resources/blogs"
+            to="/blogs"
             className="inline-flex items-center text-pink-200 hover:text-white transition-colors mb-8 group"
           >
             <ArrowLeft className="h-4 w-4 mr-2 group-hover:-translate-x-1 transition-transform" />
@@ -374,7 +374,7 @@ export default function MeetTeamJayush() {
                 title: "Meet the Team: Rojin Rezaei",
                 excerpt:
                   "Get to know Rojin Rezaei, our cybersecurity expert specializing in penetration testing",
-                link: "/resources/blog/meet-team-rojin-rezaei",
+                link: "/blog/meet-team-rojin-rezaei",
                 category: "Team Spotlight",
                 emoji: "👩‍💻",
               },
@@ -382,7 +382,7 @@ export default function MeetTeamJayush() {
                 title: "What is a vCISO?",
                 excerpt:
                   "Understanding the role of virtual Chief Information Security Officers",
-                link: "/resources/blog/what-is-vciso-role-cybersecurity",
+                link: "/blog/what-is-vciso-role-cybersecurity",
                 category: "Leadership",
                 emoji: "👨‍💼",
               },
@@ -390,7 +390,7 @@ export default function MeetTeamJayush() {
                 title: "20 Years of Cybersecurity",
                 excerpt:
                   "A journey through the evolution of cybersecurity over two decades",
-                link: "/resources/blog/20-years-cybersecurity-journey",
+                link: "/blog/20-years-cybersecurity-journey",
                 category: "Industry History",
                 emoji: "🕰️",
               },

--- a/client/pages/resources/blog/MeetTeamRojin.tsx
+++ b/client/pages/resources/blog/MeetTeamRojin.tsx
@@ -36,7 +36,7 @@ export default function MeetTeamRojin() {
 
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
           <Link
-            to="/resources/blogs"
+            to="/blogs"
             className="inline-flex items-center text-emerald-200 hover:text-white transition-colors mb-8 group"
           >
             <ArrowLeft className="h-4 w-4 mr-2 group-hover:-translate-x-1 transition-transform" />
@@ -426,7 +426,7 @@ export default function MeetTeamRojin() {
               {
                 title: "Meet the Team: Jayush Chawla",
                 excerpt: "Learn about our Senior Cybersecurity Consultant",
-                link: "/resources/blog/meet-team-jayush-chawla",
+                link: "/blog/meet-team-jayush-chawla",
                 category: "Team Spotlight",
                 emoji: "👨‍💻",
               },
@@ -434,14 +434,14 @@ export default function MeetTeamRojin() {
                 title: "Internal vs External Penetration Testing",
                 excerpt:
                   "Understanding the differences between testing approaches",
-                link: "/resources/blog/internal-vs-external-penetration-testing",
+                link: "/blog/internal-vs-external-penetration-testing",
                 category: "Penetration Testing",
                 emoji: "🔍",
               },
               {
                 title: "Top 10 Easy Online Safety Tips",
                 excerpt: "Simple security practices everyone should follow",
-                link: "/resources/blog/top-10-online-safety-tips",
+                link: "/blog/top-10-online-safety-tips",
                 category: "Security Tips",
                 emoji: "🛡️",
               },

--- a/client/pages/resources/blog/MeetTeamRojin.tsx
+++ b/client/pages/resources/blog/MeetTeamRojin.tsx
@@ -404,7 +404,7 @@ export default function MeetTeamRojin() {
                     asChild
                     className="border-white text-white bg-transparent hover:bg-white hover:text-emerald-600"
                   >
-                    <Link to="/services/penetration-testing">
+                    <Link to="/penetration-testing">
                       Learn About Our Testing
                     </Link>
                   </Button>

--- a/client/pages/resources/blog/PatientConfidentialityAi.tsx
+++ b/client/pages/resources/blog/PatientConfidentialityAi.tsx
@@ -30,7 +30,7 @@ export default function PatientConfidentialityAi() {
       {/* Hero Section */}
       <section className="pt-24 pb-16 bg-gradient-to-br from-cyan-900 via-teal-800 to-blue-900 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link to="/resources/blogs">
+          <Link to="/blogs">
             <Button
               variant="ghost"
               className="text-white hover:text-cyan-300 mb-8 group"

--- a/client/pages/resources/blog/PentestingComparison.tsx
+++ b/client/pages/resources/blog/PentestingComparison.tsx
@@ -36,7 +36,7 @@ export default function PentestingComparison() {
 
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
           <Link
-            to="/resources/blogs"
+            to="/blogs"
             className="inline-flex items-center text-red-200 hover:text-white transition-colors mb-8 group"
           >
             <ArrowLeft className="h-4 w-4 mr-2 group-hover:-translate-x-1 transition-transform" />
@@ -561,7 +561,7 @@ export default function PentestingComparison() {
               {
                 title: "Meet the Team: Rojin Rezaei",
                 excerpt: "Learn about our penetration testing specialist",
-                link: "/resources/blog/meet-team-rojin-rezaei",
+                link: "/blog/meet-team-rojin-rezaei",
                 category: "Team Spotlight",
                 emoji: "👩‍💻",
               },
@@ -569,14 +569,14 @@ export default function PentestingComparison() {
                 title: "How to Prepare for a Compliance Audit",
                 excerpt:
                   "Essential strategies for successful compliance audits",
-                link: "/resources/blog/prepare-compliance-audit-best-practices",
+                link: "/blog/prepare-compliance-audit-best-practices",
                 category: "Audit Readiness",
                 emoji: "📋",
               },
               {
                 title: "Top 10 Easy Online Safety Tips",
                 excerpt: "Simple security practices everyone should follow",
-                link: "/resources/blog/top-10-online-safety-tips",
+                link: "/blog/top-10-online-safety-tips",
                 category: "Security Tips",
                 emoji: "🛡️",
               },

--- a/client/pages/resources/blog/PrepareComplianceAudit.tsx
+++ b/client/pages/resources/blog/PrepareComplianceAudit.tsx
@@ -32,7 +32,7 @@ export default function PrepareComplianceAudit() {
 
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
           <Link
-            to="/resources/blogs"
+            to="/blogs"
             className="inline-flex items-center text-green-200 hover:text-white transition-colors mb-8 group"
           >
             <ArrowLeft className="h-4 w-4 mr-2 group-hover:-translate-x-1 transition-transform" />
@@ -542,21 +542,21 @@ export default function PrepareComplianceAudit() {
                 title: "ISO 27001 Certification Guide",
                 excerpt:
                   "Complete guide to ISO 27001 certification process and requirements.",
-                link: "/resources/blog/iso-27001-certification-guide",
+                link: "/blog/iso-27001-certification-guide",
                 category: "Compliance",
               },
               {
                 title: "Why SOC 2 Matters for Small Companies",
                 excerpt:
                   "Discover why SOC 2 compliance is crucial for companies of all sizes.",
-                link: "/resources/blog/why-soc2-matters-small-companies",
+                link: "/blog/why-soc2-matters-small-companies",
                 category: "Compliance",
               },
               {
                 title: "What is a vCISO?",
                 excerpt:
                   "Understanding the role of virtual Chief Information Security Officers.",
-                link: "/resources/blog/what-is-vciso-role-cybersecurity",
+                link: "/blog/what-is-vciso-role-cybersecurity",
                 category: "Leadership",
               },
             ].map((article, index) => (

--- a/client/pages/resources/blog/SafeguardingDataSharingTechCompanies.tsx
+++ b/client/pages/resources/blog/SafeguardingDataSharingTechCompanies.tsx
@@ -37,7 +37,7 @@ export default function SafeguardingDataSharingTechCompanies() {
       {/* Hero Section */}
       <section className="pt-24 pb-16 bg-gradient-to-br from-cyan-900 via-blue-800 to-indigo-900 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link to="/resources/blogs">
+          <Link to="/blogs">
             <Button
               variant="ghost"
               className="text-white hover:text-cyan-300 mb-8 group"
@@ -545,7 +545,7 @@ export default function SafeguardingDataSharingTechCompanies() {
                         <li>• Data inventory and classification</li>
                         <li>• Risk assessment and threat modeling</li>
                         <li>• Current security control evaluation</li>
-                        <li>• Compliance gap analysis</li>
+                        <li>�� Compliance gap analysis</li>
                       </ul>
                     </div>
                     <div>

--- a/client/pages/resources/blog/SecurityComplianceHealthCompanies.tsx
+++ b/client/pages/resources/blog/SecurityComplianceHealthCompanies.tsx
@@ -35,7 +35,7 @@ export default function SecurityComplianceHealthCompanies() {
       {/* Hero Section */}
       <section className="pt-24 pb-16 bg-gradient-to-br from-teal-900 via-cyan-800 to-blue-900 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link to="/resources/blogs">
+          <Link to="/blogs">
             <Button
               variant="ghost"
               className="text-white hover:text-teal-300 mb-8 group"

--- a/client/pages/resources/blog/Soc2SmallCompanies.tsx
+++ b/client/pages/resources/blog/Soc2SmallCompanies.tsx
@@ -32,7 +32,7 @@ export default function Soc2SmallCompanies() {
 
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
           <Link
-            to="/resources/blogs"
+            to="/blogs"
             className="inline-flex items-center text-green-200 hover:text-white transition-colors mb-8 group"
           >
             <ArrowLeft className="h-4 w-4 mr-2 group-hover:-translate-x-1 transition-transform" />
@@ -354,14 +354,14 @@ export default function Soc2SmallCompanies() {
                 title: "ISO 27001 Certification Guide",
                 excerpt:
                   "Complete guide to ISO 27001 certification process and requirements",
-                link: "/resources/blog/iso-27001-certification-guide",
+                link: "/blog/iso-27001-certification-guide",
                 category: "Compliance",
               },
               {
                 title: "How to Prepare for a Compliance Audit",
                 excerpt:
                   "Essential strategies for successful compliance audits",
-                link: "/resources/blog/prepare-compliance-audit-best-practices",
+                link: "/blog/prepare-compliance-audit-best-practices",
                 category: "Audit Readiness",
               },
               {
@@ -369,7 +369,7 @@ export default function Soc2SmallCompanies() {
                   "Com-Sec: Your Trusted Partner in Achieving SOC2 Compliance",
                 excerpt:
                   "Learn how Com-Sec helps organizations achieve SOC 2 compliance",
-                link: "/resources/blog/comsec-trusted-partner-soc2",
+                link: "/blog/comsec-trusted-partner-soc2",
                 category: "Company",
               },
             ].map((article, index) => (

--- a/client/pages/resources/blog/Soc2SmallCompanies.tsx
+++ b/client/pages/resources/blog/Soc2SmallCompanies.tsx
@@ -292,7 +292,7 @@ export default function Soc2SmallCompanies() {
                     </Link>
                   </Button>
                   <Button variant="outline" asChild>
-                    <Link to="/services/soc2-readiness">
+                    <Link to="/soc2-readiness">
                       Learn About Our SOC 2 Services
                     </Link>
                   </Button>

--- a/client/pages/resources/blog/Soc2VsIso27001.tsx
+++ b/client/pages/resources/blog/Soc2VsIso27001.tsx
@@ -32,7 +32,7 @@ export default function Soc2VsIso27001() {
       {/* Hero Section */}
       <section className="pt-24 pb-16 bg-gradient-to-br from-slate-900 via-blue-900 to-indigo-900 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link to="/resources/blogs">
+          <Link to="/blogs">
             <Button
               variant="ghost"
               className="text-white hover:text-blue-300 mb-8 group"

--- a/client/pages/resources/blog/Top10OnlineSafetyTips.tsx
+++ b/client/pages/resources/blog/Top10OnlineSafetyTips.tsx
@@ -31,7 +31,7 @@ export default function Top10OnlineSafetyTips() {
       {/* Hero Section */}
       <section className="pt-24 pb-16 bg-gradient-to-br from-orange-700 via-red-600 to-pink-700 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link to="/resources/blogs">
+          <Link to="/blogs">
             <Button
               variant="ghost"
               className="text-white hover:text-orange-300 mb-8 group"

--- a/client/pages/resources/blog/TransparencyAccuracyAiHealthcare.tsx
+++ b/client/pages/resources/blog/TransparencyAccuracyAiHealthcare.tsx
@@ -31,7 +31,7 @@ export default function TransparencyAccuracyAiHealthcare() {
       {/* Hero Section */}
       <section className="pt-24 pb-16 bg-gradient-to-br from-emerald-900 via-teal-800 to-cyan-900 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <Link to="/resources/blogs">
+          <Link to="/blogs">
             <Button
               variant="ghost"
               className="text-white hover:text-emerald-300 mb-8 group"

--- a/client/pages/resources/blog/WhatIsVciso.tsx
+++ b/client/pages/resources/blog/WhatIsVciso.tsx
@@ -33,7 +33,7 @@ export default function WhatIsVciso() {
 
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
           <Link
-            to="/resources/blogs"
+            to="/blogs"
             className="inline-flex items-center text-purple-200 hover:text-white transition-colors mb-8 group"
           >
             <ArrowLeft className="h-4 w-4 mr-2 group-hover:-translate-x-1 transition-transform" />

--- a/client/pages/services/ComplianceAuditReadiness.tsx
+++ b/client/pages/services/ComplianceAuditReadiness.tsx
@@ -150,7 +150,7 @@ export default function ComplianceAuditReadiness() {
                 color: "bg-orange-50 border-orange-200",
               },
             ].map((framework) => (
-              <Link key={framework.slug} to={`/frameworks/${framework.slug}`} className="no-underline">
+              <Link key={framework.slug} to={`/${framework.slug}`} className="no-underline">
                 <Card
                   className={`text-center hover:shadow-lg transition-all duration-300 border-2 ${framework.color}`}
                 >
@@ -482,7 +482,7 @@ export default function ComplianceAuditReadiness() {
               className="border-emerald-600 text-emerald-600 hover:bg-emerald-600 hover:text-white"
               asChild
             >
-              <Link to="/frameworks/soc2">
+              <Link to="/soc2">
                 Explore Frameworks
                 <ArrowRight className="ml-2 h-5 w-5" />
               </Link>


### PR DESCRIPTION
### Purpose

Based on the conversation history, the goal is to standardize and simplify the internal linking structure. This involves removing prefixes such as `/frameworks/`, `/services/`, `/resources/`, and `/about/` from all internal URLs to create shorter and more consistent paths.

### Code changes

- Updated the `to` prop in `Link` components across multiple files to remove URL prefixes.
- Removed the `/frameworks/` prefix from links in `Navigation.tsx` and `ComplianceAuditReadiness.tsx`.
- Removed the `/services/` prefix from links in `Footer.tsx` and `Navigation.tsx`.
- Removed the `/resources/` prefix from links in `Navigation.tsx` and various blog pages.
- Removed the `/about/` prefix from links in `Navigation.tsx`.
- This ensures all internal links now use the simplified, root-level path structure.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b77c975942a74625adb8502ac720d627/cosmos-zone)

👀 [Preview Link](https://b77c975942a74625adb8502ac720d627-cosmos-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b77c975942a74625adb8502ac720d627</projectId>-->
<!--<branchName>cosmos-zone</branchName>-->