### PR TITLE
fix: add compliance-audit-readiness route and clean up sitemap

### DIFF
--- a/client/main.tsx
+++ b/client/main.tsx
@@ -179,6 +179,7 @@ const App = () => (
               {/* Service Routes */}
               <Route path="/services" element={<Services />} />
               <Route path="/services/compliance-audit-readiness" element={<ComplianceAuditReadiness />} />
+              <Route path="/compliance-audit-readiness" element={<ComplianceAuditReadiness />} />
               <Route path="/services/penetration-testing-services" element={<Navigate to="/penetration-testing-services" replace />} />
               <Route path="/services/it-support" element={<Navigate to="/it-support" replace />} />
               <Route path="/services/soc-support" element={<Navigate to="/soc-support" replace />} />

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -235,15 +235,7 @@
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://com-sec.io/blog/security-compliance-health-companies</loc>
-    <priority>0.7</priority>
-  </url>
-  <url>
     <loc>https://com-sec.io/blog/cybersecurity-roundup-startups-may</loc>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://com-sec.io/blog/transparency-accuracy-ai-healthcare</loc>
     <priority>0.7</priority>
   </url>
   <url>
@@ -255,15 +247,7 @@
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://com-sec.io/blog/patient-confidentiality-ai-healthcare</loc>
-    <priority>0.7</priority>
-  </url>
-  <url>
     <loc>https://com-sec.io/blog/ai-ethics-healthcare-innovation</loc>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://com-sec.io/blog/managed-security-compliance-services</loc>
     <priority>0.7</priority>
   </url>
   <url>


### PR DESCRIPTION
- Add direct route /compliance-audit-readiness alongside /services/compliance-audit-readiness
- Remove stale blog entries from sitemap.xml