### PR TITLE
Remove "based on scope" badge subtext from pricing card

### DIFF
--- a/client/pages/Pricing.tsx
+++ b/client/pages/Pricing.tsx
@@ -103,7 +103,6 @@ const oneTimeEngagements = [
     ],
     simplePrice: true,
     badge: "BEST VALUE",
-    badgeSubtext: "based on scope",
     pricingDisplay: {
       headline: "All-Inclusive",
       price: "$18,500",

--- a/client/pages/Pricing.tsx
+++ b/client/pages/Pricing.tsx
@@ -297,9 +297,11 @@ export default function Pricing() {
                           <p className="text-3xl font-bold text-orange-400">
                             {service.pricingDisplay?.price || service.startingPrice}
                           </p>
-                          <p className="text-xs text-slate-400 mt-2">
-                            {service.pricingDisplay?.subtext || "Custom pricing available based on scope"}
-                          </p>
+                          {service.pricingDisplay?.subtext && (
+                            <p className="text-xs text-slate-400 mt-2">
+                              {service.pricingDisplay.subtext}
+                            </p>
+                          )}
                         </div>
 
                         {/* Highlights Section - Services/Frameworks */}


### PR DESCRIPTION
### Summary
Removes the "based on scope" badge subtext from the Best Value pricing card and conditionally renders the pricing subtext only when it exists.

### Problem
The orange "based on scope" subtext was appearing on the top pricing card undesirably, and a fallback string ("Custom pricing available based on scope") was always rendering even when no subtext was defined.

### Key Changes
- Removed `badgeSubtext: "based on scope"` from the Best Value one-time engagement entry
- Changed the pricing subtext `<p>` to render conditionally only when `service.pricingDisplay?.subtext` is defined, eliminating the hardcoded fallback string

---

<a href="https://builder.io/app/projects/b77c975942a74625adb8502ac720d627/satin-league-v486jlq0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://b77c975942a74625adb8502ac720d627-satin-league-v486jlq0_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=b77c975942a74625adb8502ac720d627&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 58`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b77c975942a74625adb8502ac720d627</projectId>-->
<!--<branchName>satin-league-v486jlq0</branchName>-->